### PR TITLE
Support Calico data source for peering

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_script:
   - ./CI/playbook_check_container_version.sh
 script:
   - ./CI/container_build.sh
-  - ./CI/container_test.sh
+  - ./CI/container_DS-MRT_test.sh
+  - ./CI/container_DS-Calico_test.sh
 after_success:
   - ./CI/container_push.sh

--- a/CI/container_DS-Calico_test.sh
+++ b/CI/container_DS-Calico_test.sh
@@ -1,0 +1,259 @@
+#!/bin/bash
+
+#set -o errexit
+set -o nounset
+set -o pipefail
+
+#set -x
+
+if [ "$TRAVIS_PULL_REQUEST_BRANCH" != "" ]; then
+     echo "Test of container skipped for PR. Container will be tested and uploaded after merge."
+     exit 0
+fi
+
+DATE=$(date "+%Y%m%d")
+WD="$(pwd)/bird-container/tmp-$DATE"
+IMG_ID=$(tail -n 10 $WD/build.log  | grep 'Successfully built' | awk '{print $3}')
+
+if [ "$IMG_ID" == "" ] ; then
+    echo "Container was not successfully built."
+    exit 1
+fi
+
+echo "Testing BIRD containers functional for native Calico data source"
+echo
+
+echo "Run etcd container"
+ETCDC=$(docker run -d xenolog/etcd:latest)
+ETCD_IP=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' $ETCDC)
+sleep 2  # waiting for etcd run
+echo "..ETCD IP: $ETCD_IP"
+
+echo "Run Rack-1 RR1 container"
+RRC_11=$(docker run -d -e RACK=1 -e BGPD_MODE=RR -e RR_BGP_PORT=180 -e PEERING_SOURCE=calico -e HOSTNAME=node-01-001 -e ETCD_AUTHORITY=http://${ETCD_IP}:2379/ $IMG_ID)
+RACK1_RR1_IP=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' $RRC_11)
+echo "..Rack-1/RR1 IP: $RACK1_RR1_IP"
+
+echo "Run Rack-1 RR2 container"
+RRC_12=$(docker run -d -e RACK=1 -e BGPD_MODE=RR -e RR_BGP_PORT=180 -e PEERING_SOURCE=calico -e HOSTNAME=node-01-002 -e ETCD_AUTHORITY=http://${ETCD_IP}:2379/ $IMG_ID)
+RACK1_RR2_IP=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' $RRC_12)
+echo "..Rack-1/RR2 IP: $RACK1_RR2_IP"
+
+echo "Run Rack-1/peer-1 container"
+PEER11C=$(docker run --privileged -d -e RACK=1 -e RR_BGP_PORT=180 -e PEERING_SOURCE=calico -e HOSTNAME=node-01-003 -e ETCD_AUTHORITY=http://${ETCD_IP}:2379/ $IMG_ID)
+PEER11_IP=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' $PEER11C)
+echo "..Rack-1/peer-1 IP: $PEER11_IP"
+
+echo "Run Rack-1 peer-2 container"
+PEER12C=$(docker run --privileged -d -e RACK=1 -e RR_BGP_PORT=180 -e PEERING_SOURCE=calico -e HOSTNAME=node-01-004 -e ETCD_AUTHORITY=http://${ETCD_IP}:2379/ $IMG_ID)
+PEER12_IP=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' $PEER12C)
+echo "..Rack-1/peer-2 IP: $PEER12_IP"
+
+
+echo "Run Rack-2 RR container"
+RRC_2=$(docker run -d -e RACK=2 -e BGPD_MODE=RR -e RR_BGP_PORT=180 -e PEERING_SOURCE=calico -e HOSTNAME=node-02-001 -e ETCD_AUTHORITY=http://${ETCD_IP}:2379/ $IMG_ID)
+RACK2_RR_IP=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' $RRC_2)
+echo "..Rack-2/RR IP: $RACK2_RR_IP"
+
+echo "Run Rack-2 peer-1 container"
+PEER21C=$(docker run --privileged -d -e RACK=2 -e RR_BGP_PORT=180 -e PEERING_SOURCE=calico -e HOSTNAME=node-02-002 -e ETCD_AUTHORITY=http://${ETCD_IP}:2379/ $IMG_ID)
+PEER21_IP=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' $PEER21C)
+echo "..Rack-2/peer-1 IP: $PEER21_IP"
+
+echo "Run Rack-2 peer-2 container"
+PEER22C=$(docker run --privileged -d -e RACK=2 -e RR_BGP_PORT=180 -e PEERING_SOURCE=calico -e HOSTNAME=node-02-003 -e ETCD_AUTHORITY=http://${ETCD_IP}:2379/ $IMG_ID)
+PEER22_IP=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' $PEER22C)
+echo "..Rack-2/peer-2: $PEER22_IP"
+
+RACK1_TOR_IP="10.222.1.254"
+RACK2_TOR_IP="10.222.2.254"
+
+echo
+echo "Upload '/multirack_topology' data structure into etcd"
+cat << EOF > /tmp/multirack_topology.yaml
+racks:
+  "1":
+    rack_no: 1
+    as_number: 65001
+    tor: "${RACK1_TOR_IP}"
+    bgpport: 179
+  "2":
+    rack_no: 2
+    as_number: 65002
+    tor: "${RACK2_TOR_IP}"
+    bgpport: 179
+EOF
+docker cp /tmp/multirack_topology.yaml $ETCDC:/tmp/
+docker exec $ETCDC etcdtool import -y -f yaml /multirack_topology /tmp/multirack_topology.yaml
+docker exec $ETCDC etcdtool export -f yaml /multirack_topology
+echo
+echo "Upload '/calico' data structure into etcd"
+cat << EOF > /tmp/calico.yaml
+bgp:
+  v1:
+    global:
+      as_num: "64512"
+      node_mesh: '{"enabled":false}'
+    rr_v4:
+      ${RACK1_RR1_IP}: '{"ip":"${RACK1_RR1_IP}","cluster_id":"1","as_num":"65001"}'
+      ${RACK1_RR2_IP}: '{"ip":"${RACK1_RR2_IP}","cluster_id":"1","as_num":"65001"}'
+      ${RACK2_RR_IP}: '{"ip":"${RACK2_RR_IP}","cluster_id":"2","as_num":"65002"}'
+    host:
+      node-01-001:
+        as_num: 65001
+        ip_addr_v4: ${RACK1_RR1_IP}
+      node-01-002:
+        as_num: 65001
+        ip_addr_v4: ${RACK1_RR2_IP}
+      node-01-003:
+        ip_addr_v4: ${PEER11_IP}
+        as_num: 65001
+        peer_v4:
+          ${RACK1_RR1_IP}: '{"ip":"${RACK1_RR1_IP}","as_num":"65001"}'
+          ${RACK1_RR2_IP}: '{"ip":"${RACK1_RR2_IP}","as_num":"65001"}'
+      node-01-004:
+        ip_addr_v4: ${PEER12_IP}
+        as_num: 65001
+        peer_v4:
+          ${RACK1_RR1_IP}: '{"ip":"${RACK1_RR1_IP}","as_num":"65001"}'
+          ${RACK1_RR2_IP}: '{"ip":"${RACK1_RR2_IP}","as_num":"65001"}'
+      node-02-001:
+        ip_addr_v4: ${RACK2_RR_IP}
+        as_num: 65002
+      node-02-002:
+        ip_addr_v4: ${PEER21_IP}
+        as_num: 65002
+        peer_v4:
+          ${RACK2_RR_IP}: '{"ip":"${RACK2_RR_IP}","as_num":"65002"}'
+      node-02-003:
+        ip_addr_v4: ${PEER22_IP}
+        as_num: 65002
+        peer_v4:
+          ${RACK2_RR_IP}: '{"ip":"${RACK2_RR_IP}","as_num":"65002"}'
+EOF
+docker cp /tmp/calico.yaml $ETCDC:/tmp/
+docker exec $ETCDC etcdtool import -y -f yaml /calico /tmp/calico.yaml
+docker exec $ETCDC etcdtool export -f yaml /calico
+echo "..done"
+
+TESTS_FAILED=""
+
+echo
+echo "Check for all bgpd started"
+sleep 120  # this sleep required, because containers starts before data source wes ready
+err=""
+for i in $RRC_11 $RRC_12 $RRC_2 $PEER11C $PEER12C $PEER21C $PEER22C ; do
+  docker exec $i ps axf | grep ' bird ' ; rc=$?
+  test $rc != 0 && err="$err $i"
+done
+if [ "$err" != "" ] ; then
+    err="Bird not started for nodes: $err"
+    echo ".-$err"
+    TESTS_FAILED="${TESTS_FAILED}\n${err}"
+else
+    echo "..OK"
+fi
+
+echo
+echo "Check bgpd sessions into Rack-1 RR-to-Peers"
+sleep 2
+sess=$(docker exec $RRC_11 birdc sh proto | grep ' BGP ')
+echo $sess
+for i in $PEER11_IP $PEER12_IP $RACK1_RR2_IP ; do
+    echo $sess | grep $i 2>&1 > /dev/null ; rc=$?
+    if [ $rc == 0 ] ; then
+        echo "..session with $i is OK"
+    else
+        err="No BGP session RR-to-$i"
+        echo ".-$err"
+        TESTS_FAILED="${TESTS_FAILED}\n${err}"
+    fi
+done
+sess=$(docker exec $RRC_12 birdc sh proto | grep ' BGP ')
+echo $sess
+for i in $PEER11_IP $PEER12_IP $RACK1_RR1_IP ; do
+    echo $sess | grep $i 2>&1 > /dev/null ; rc=$?
+    if [ $rc == 0 ] ; then
+        echo "..session with $i is OK"
+    else
+        err="No BGP session RR-to-$i"
+        echo ".-$err"
+        TESTS_FAILED="${TESTS_FAILED}\n${err}"
+    fi
+done
+for i in $PEER21_IP $PEER22_IP RACK2_RR_IP; do
+    echo $sess | grep $i 2>&1 > /dev/null ; rc=$?
+    if [ $rc == 0 ] ; then
+        err="Unrequired BGP session RR-to-$i found"
+        echo ".-$err"
+        TESTS_FAILED="${TESTS_FAILED}\n${err}"
+    fi
+done
+sess=$(docker exec $RRC_2 birdc sh proto | grep ' BGP ')
+echo $sess
+for i in $PEER21_IP $PEER22_IP ; do
+    echo $sess | grep $i 2>&1 > /dev/null ; rc=$?
+    if [ $rc == 0 ] ; then
+        echo "..session with $i is OK"
+    else
+        err="No BGP session RR-to-$i"
+        echo ".-$err"
+        TESTS_FAILED="${TESTS_FAILED}\n${err}"
+    fi
+done
+for i in $PEER11_IP $PEER12_IP $RACK1_RR1_IP $RACK1_RR2_IP; do
+    echo $sess | grep $i 2>&1 > /dev/null ; rc=$?
+    if [ $rc == 0 ] ; then
+        err="Unrequired BGP session RR-to-$i found"
+        echo ".-$err"
+        TESTS_FAILED="${TESTS_FAILED}\n${err}"
+    fi
+done
+
+# echo
+# echo "Check bgpd sessions between Peers and RR"
+# for id in $PEER11C $PEER12C ; do
+#   ip=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' $id)
+#   sess=$(docker exec $id birdc sh proto | grep ' BGP ')
+#   echo $sess | grep $RACK1_RR_IP 2>&1 > /dev/null ; rc=$?
+#     if [ $rc == 0 ] ; then
+#         echo "..session from $ip to RR is OK"
+#     else
+#         err="No BGP session from $ip-to-RR"
+#         echo ".-$err"
+#         TESTS_FAILED="${TESTS_FAILED}\n${err}"
+#     fi
+# done
+
+# echo
+# echo "Check IP address re-distributiion between peers"
+# ip="1.2.3.4"
+# docker exec $PEER11C ip a add $ip/32 dev lo
+# sleep 30
+# docker exec $PEER12C ip r show | grep bird | grep $ip ; rc=$?
+# if [ $rc == 0 ] ; then
+#     echo "..IP routes re-distribution is OK"
+# else
+#     err="No IP routes re-distribution"
+#     echo ".-$err"
+#     TESTS_FAILED="${TESTS_FAILED}\n${err}"
+# fi
+
+echo
+echo "Remove test env. containers:"
+docker kill $ETCDC
+docker rm -f $ETCDC
+for i in $RRC_11 $RRC_12 $RRC_2 $PEER11C $PEER12C $PEER21C $PEER22C ; do
+    #docker cp "${i}:/etc/bird/bird.conf" /tmp/
+    #mv /tmp/bird.conf /tmp/bird.conf-$(docker exec -it $i env | grep HOSTNAME | awk -F= '{print $2}')
+    docker kill $i
+    docker rm -f $i
+done
+
+echo
+if [ "$TESTS_FAILED" != "" ] ; then
+    echo "Failed tests:"
+    echo -e $TESTS_FAILED
+    exit 1
+fi
+echo "All tests passed..."

--- a/CI/container_DS-MRT_test.sh
+++ b/CI/container_DS-MRT_test.sh
@@ -20,6 +20,8 @@ if [ "$IMG_ID" == "" ] ; then
     exit 1
 fi
 
+echo "Testing BIRD containers functional for 'multirack_topology' data source"
+echo
 echo "Run etcd container"
 ETCDC=$(docker run -d xenolog/etcd:latest)
 ETCD_IP=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' $ETCDC)
@@ -42,7 +44,7 @@ PEER2_IP=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' $PEER2C)
 echo "..Peer-2 IP: $PEER2_IP"
 
 echo
-echo "Upload multirack_topology data structure into etcd"
+echo "Upload '/multirack_topology' data structure into etcd"
 cat << EOF > /tmp/multirack_topology.yaml
 racks:
   "1":

--- a/README.md
+++ b/README.md
@@ -95,5 +95,20 @@ HOSTNAME=svasilenko-01-001
 RACK=1
 BGPD_MODE=RR  # may be RR or NODE (default)
 IP=10.222.1.1
+RR_BGP_PORT=179
+TOR_BGP_PORT=179
+PEERING_SOURCE=calico  # NT (default) or Calico
 DEBUG=1
+```
+
+If 'calico' PEERING_SOURCE used, you can (but not obligatory) extend calico data model by custom fields:
+```
+calico:
+  bgp:
+    v1:
+      rr_v4:
+        10.222.1.1: '{"ip":"10.222.1.1","cluster_id":"1"}'
+                  # \ default Calico's RR definition
+        10.222.2.1: '{"ip":"10.222.2.1","cluster_id":"2","as_num":"64444","bgp_port":"180"}'
+                  # \ Extended RR definition with AS number and BGP port specifyed
 ```

--- a/bird-container/root/etc/confd/conf.d/bird_calico.toml
+++ b/bird-container/root/etc/confd/conf.d/bird_calico.toml
@@ -1,0 +1,12 @@
+[template]
+prefix = ""
+src = "bird_calico.tmpl"
+dest = "/etc/bird/bird.conf"
+owner = "root"
+mode = "0644"
+keys = [
+  "/calico/bgp/v1",
+  "/multirack_topology",
+]
+check_cmd = "bird -p -c {{.src}}"
+reload_cmd = "birdcl -s /var/run/bird.ctl configure"

--- a/bird-container/root/etc/confd/templates/bird.tmpl
+++ b/bird-container/root/etc/confd/templates/bird.tmpl
@@ -1,7 +1,7 @@
-{{$rack_no := getenv "RACK"}}
-{{$bgpd_mode := getenv "BGPD_MODE"}}
-{{$local_ipaddr := getenv "IP"}}
-{{$local_asnum := getv (printf "/racks/%s/as_number" $rack_no)}}
+{{- $rack_no := getenv "RACK" -}}
+{{- $bgpd_mode := getenv "BGPD_MODE" -}}
+{{- $local_ipaddr := getenv "IP" -}}
+{{- $local_asnum := getv (printf "/racks/%s/as_number" $rack_no) -}}
 
 # Configure logging
 #log syslog { debug, trace, info, remote, warning, error, auth, fatal, bug };

--- a/bird-container/root/etc/confd/templates/bird_calico.tmpl
+++ b/bird-container/root/etc/confd/templates/bird_calico.tmpl
@@ -1,0 +1,221 @@
+{{- $rack_no := getenv "RACK" -}}
+{{- $bgpd_mode := getenv "BGPD_MODE" -}}
+{{- $local_ipaddr := getenv "IP" -}}
+{{- $local_hostname := getenv "HOSTNAME" -}}
+{{- $p_calico := getenv "PREFIX_CALICO" "/calico/bgp/v1" -}}
+{{- $p_mr := getenv "PREFIX_MULTIRACK" "/multirack_topology" -}}
+{{- $rr_bgp_port := getenv "RR_BGP_PORT" "179" -}}
+{{- $node_bgp_port := getenv "NODE_BGP_PORT" "179" -}}
+{{- $tor_bgp_port := getenv "TOR_BGP_PORT" "179" -}}
+{{- $global_asnum := getv (printf "%s/global/as_num" $p_calico) "65000" -}}
+
+# bird.conf for node '{{$local_hostname}}'
+
+# Configure logging
+#log syslog { debug, trace, info, remote, warning, error, auth, fatal, bug };
+log stderr all;
+
+{{- if ne $bgpd_mode "RR" }}
+# Override router ID
+router id {{$local_ipaddr}};
+{{- end }}
+
+# Turn on global debugging of all protocols
+debug protocols all;
+
+# This pseudo-protocol watches all interface up/down events.
+protocol device {
+  scan time 2;    # Scan interfaces every 2 seconds
+}
+
+{{if ne $bgpd_mode "RR"}}
+# Node-specific global configuration options
+
+listen bgp address {{$local_ipaddr}} port {{$node_bgp_port}};
+
+filter exported_by_bgp {
+  if ( (ifname ~ "tap*") || (ifname ~ "cali*") || (ifname ~ "dummy1") || (ifname ~ "lo")) then {
+    if net != 0.0.0.0/0 then accept;
+  }
+  reject;
+}
+
+# Configure synchronization between BIRD's routing tables and the
+# kernel.
+protocol kernel {
+  learn;          # Learn all alien routes from the kernel
+  persist;        # Don't remove routes on bird shutdown
+  scan time 2;    # Scan kernel routing table every 2 seconds
+  import all;
+  export all;     # Default is export none
+  merge paths;    # For ECMP in routing table
+  graceful restart;
+}
+
+protocol direct {
+   debug all;
+   interface "-docker*", "*";
+}
+
+{{end}}
+
+{{- if eq $bgpd_mode "RR" -}}
+
+listen bgp address {{$local_ipaddr}} port {{$rr_bgp_port}};
+
+
+  {{- $our_rr_key := printf "%s/rr_v4/%s" $p_calico $local_ipaddr -}}
+  {{- if ls $our_rr_key -}}
+    {{- $our_rr_data := json (getv $our_rr_key) -}}
+    {{- $our_cluster_id := $our_rr_data.cluster_id -}}
+    {{- $local_asnum := or $our_rr_data.as_num $global_asnum -}}
+
+    {{- if ls (printf "%s/rr_v4" $p_calico) }}
+
+
+###
+# RR mode. Sessions with another RR from my rack (with the same 'cluster_id')
+    {{- range gets (printf "%s/rr_v4/*" $p_calico) -}}
+      {{- $data := json .Value -}}
+      {{- $rr_ipaddr := $data.ip -}}
+      {{- $name := printf "RR-%s" $rr_ipaddr -}}
+      {{- if ne $rr_ipaddr $local_ipaddr -}}
+        {{- if eq $data.cluster_id $our_cluster_id -}}
+          {{- $rr_bgp_port_str := printf "port %s" (or $data.bgp_port $rr_bgp_port) }}
+protocol bgp '{{$name}}' {
+  local as {{$local_asnum}};
+  neighbor {{$rr_ipaddr}} {{$rr_bgp_port_str}} as {{$local_asnum}};
+  description "{{$name}}";
+  multihop;
+  import all;
+  export all;
+  next hop keep;
+  add paths;     # For ECMP in BGP session with TOR
+  source address {{$local_ipaddr}};
+}
+{{end}}{{end}}{{end}}{{end}}
+
+  {{- if ls (printf "%s/host" $p_calico) }}
+
+
+###
+# RR mode. Sessions with nodes in my rack
+    {{- range $cnode := lsdir (printf "%s/host" $p_calico) -}}
+      {{- $node_peers_key := printf "%s/host/%s/peer_v4" $p_calico $cnode -}}
+      {{- if ls $node_peers_key -}}
+        {{- range $peer := gets (printf "%s/*" $node_peers_key) -}}
+          {{- $data := json $peer.Value -}}
+          {{- if eq $data.ip $local_ipaddr -}}
+            {{- $cnode_ip := getv (printf "%s/host/%s/ip_addr_v4" $p_calico $cnode) -}}
+            {{- $name := printf "node-%s" $cnode_ip }}
+protocol bgp '{{$name}}' {
+  local as {{getv (printf "%s/host/%s/as_num" $p_calico $cnode) $global_asnum}};
+  neighbor {{$cnode_ip}} as {{getv (printf "%s/host/%s/as_num" $p_calico $cnode) $global_asnum}};
+  description "{{$name}}";
+  multihop;
+  rr client;
+  rr cluster id {{$our_cluster_id}};
+  import all;
+  export all;
+  add paths;
+  next hop keep;
+  source address {{$local_ipaddr}};
+}
+{{end}}{{end}}{{end}}{{end}}{{end}}
+
+  {{- if exists (printf "%s/global/peer_v4" $p_calico) }}
+
+
+###
+# RR mode. Sessions with global peers
+    {{- range gets (printf "%s/global/peer_v4/*" $p_calico) }}
+      {{- $data := json .Value -}}
+      {{- if ne $data.ip $local_ipaddr -}}
+        {{- if eq $data.as_num $local_asnum }}
+protocol bgp 'global-peer-iBGP-{{$data.ip}}' {
+  local as {{$local_asnum}};
+  neighbor {{$data.ip}} as {{$local_asnum}};
+  description "global-peer-iBGP-{{$data.ip}}";
+  rr client;
+  rr cluster id {{$our_cluster_id}};
+  multihop;
+  import all;
+  export all;
+  next hop keep;
+  add paths;     # For ECMP in BGP session with TOR
+  source address {{$local_ipaddr}};
+}
+{{end}}{{end}}{{end}}{{end}}
+
+  {{ if ls (printf "%s/racks/%s" $p_mr $rack_no) }}
+    {{- $tor_ipaddr_key := printf "%s/racks/%s/tor" $p_mr $rack_no -}}
+    {{- if exists $tor_ipaddr_key -}}
+      {{- $tor_asnum := getv (printf "%s/racks/%s/as_number" $p_mr $rack_no) $local_asnum -}}
+      {{- $tor_bgp_port_str := printf "port %s" (getv (printf "%s/racks/%s/bgpport" $p_mr $rack_no) $tor_bgp_port) -}}
+      {{- $tor_ipaddr := getv $tor_ipaddr_key }}
+
+###
+# session with TOR switch
+protocol bgp 'TOR-rack{{$rack_no}}-{{$tor_ipaddr}}' {
+  local as {{$tor_asnum}};
+  neighbor {{$tor_ipaddr}} {{$tor_bgp_port_str}} as {{$tor_asnum}};
+  description "TOR-{{$tor_ipaddr}}";
+  multihop;
+  rr client;
+  import all;
+  export all;
+  next hop keep;
+  add paths;     # For ECMP in BGP session with TOR
+  source address {{$local_ipaddr}};
+}
+{{end}}{{end}}
+
+{{end}}
+{{else}}
+
+  {{- $our_node_key := printf "%s/host/%s" $p_calico $local_hostname -}}
+  {{- $local_asnum := getv (printf "%s/as_num" $our_node_key) $global_asnum -}}
+  {{- if ls (printf "%s/peer_v4" $our_node_key) }}
+
+###
+# Node mode. Sessions with my local peers
+    {{- range $peer := gets (printf "%s/peer_v4/*" $our_node_key) -}}
+      {{- $peer_data := json $peer.Value -}}
+      {{- $rr_data := json (getv (printf "%s/rr_v4/%s" $p_calico $peer_data.ip) "{}") }}
+      {{- $peer_bgp_port_str := printf "port %s" (or $peer_data.bgp_port $rr_data.bgp_port $rr_bgp_port) -}}
+      {{- $name := printf "peer-%s" $peer_data.ip }}
+protocol bgp '{{$name}}' {
+  local as {{$peer_data.as_num}};
+  neighbor {{$peer_data.ip}} {{$peer_bgp_port_str}} as {{$peer_data.as_num}};
+  description "{{$name}}";
+  import all;
+  export filter exported_by_bgp;
+  add paths;
+  next hop self;
+  source address {{$local_ipaddr}};
+}
+    {{- end -}}
+  {{- end -}}
+
+  {{- if ls (printf "%s/global/peer_v4" $p_calico) }}
+
+###
+# Node mode. Sessions with global peers
+    {{- range gets (printf "%s/global/peer_v4/*" $p_calico) }}
+      {{- $data := json .Value -}}
+      {{- $name := printf "global-peer-%s" $data.ip }}
+protocol bgp '{{$name}}' {
+  local as {{$local_asnum}};
+  neighbor {{$data.ip}} as {{or $data.as_num $local_asnum}};
+  description "{{$name}}";
+  multihop;
+  import all;
+  export filter exported_by_bgp;
+  next hop keep;
+  add paths;     # For ECMP in BGP session with TOR
+  source address {{$local_ipaddr}};
+}
+    {{end}}
+  {{end}}
+
+{{end}}

--- a/bird-container/root/etc/sv/confd/run
+++ b/bird-container/root/etc/sv/confd/run
@@ -10,6 +10,12 @@ else
     DBG='--log-level=error'
 fi
 
+if [ "${PEERING_SOURCE}" == "calico" ] ; then
+    rm -f /etc/confd/conf.d/bird.toml
+else
+    rm -f /etc/confd/conf.d/bird_calico.toml
+fi
+
 ETCD_ENDPOINTS_CONFD=$(echo "-node=$ETCD_AUTHORITY" | sed -e 's/,/ -node=/g')
 
 exec confd -confdir=/etc/confd -interval=5 -watch $DBG $ETCD_ENDPOINTS_CONFD


### PR DESCRIPTION
This patchset add ability to use /calico tree into etcd
as data-source for peering between k8s nodes and RRs.

Container-related logic implemented here.